### PR TITLE
Oparl-Configuration in dotenv #69

### DIFF
--- a/importer/oparl_auto.py
+++ b/importer/oparl_auto.py
@@ -8,6 +8,7 @@ from importer import CityToAGS
 from importer.citytools import import_streets, import_outline
 from importer.functions import get_importer
 from importer.oparl_helper import default_options
+from importer.sternberg_import import SternbergImport
 from meine_stadt_transparent import settings
 
 logger = logging.getLogger(__name__)
@@ -92,8 +93,13 @@ class OParlAuto:
         logger.info("We're done with the OParl import. We just need some metadata now")
         import_streets(main_body, ags)
         import_outline(main_body, ags)
-        logger.info("Done! Please add the following line to your dotenv file: \nSITE_DEFAULT_BODY={}"
-                    .format(main_body.id))
+
+        dotenv = "SITE_DEFAULT_BODY={}".format(main_body.id) + "\n" \
+                 + "OPARL_ENDPOINT={}".format(importer.entrypoint)
+        if isinstance(importer, SternbergImport):
+            dotenv += "\nOPARL_WORKAROUNDS=Sternberg"
+
+        logger.info("Done! Please add the following line to your dotenv file: \n" + dotenv)
 
     @classmethod
     def get_ags(cls, liboparl_body, userinput):

--- a/importer/oparl_helper.py
+++ b/importer/oparl_helper.py
@@ -23,13 +23,14 @@ from gi.repository import Json, GLib, OParl
 default_options = {
     "download_files": True,
     "use_cache": True,
-    "use_sternberg": False,
+    "use_sternberg": (settings.OPARL_WORKAROUNDS and settings.OPARL_WORKAROUNDS.lower() == "sternberg"),
     "ignore_modified": False,
     "no_threads": False,
     "cachefolder": settings.CACHE_ROOT,
     "storagefolder": settings.MEDIA_ROOT,
     "batchsize": 100,
     "threadcount": 10,
+    "entrypoint": settings.OPARL_ENDPOINT,
 }
 
 

--- a/mainapp/management/commands/importanything.py
+++ b/mainapp/management/commands/importanything.py
@@ -7,8 +7,8 @@ from .importoparl import Command as ImportOParlCommand
 class Command(ImportOParlCommand):
     help = 'Import the bodies from an oparl api into the database'
 
-    def add_arguments(self, parser, add_entrypoint=True):
-        super().add_arguments(parser, add_entrypoint)
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
         parser.add_argument('url', type=str)
 
     def handle(self, *args, **options):

--- a/mainapp/management/commands/importlist.py
+++ b/mainapp/management/commands/importlist.py
@@ -5,8 +5,8 @@ from .importoparl import Command as ImportOParlCommand
 class Command(ImportOParlCommand):
     help = 'Import the bodies from an oparl api into the database'
 
-    def add_arguments(self, parser, add_entrypoint=True):
-        super().add_arguments(parser, add_entrypoint)
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
         parser.add_argument('list', choices=["paper", "person", "organization", "meeting"])
         parser.add_argument('--cutoff', type=int)
 

--- a/mainapp/management/commands/importoparl.py
+++ b/mainapp/management/commands/importoparl.py
@@ -6,10 +6,9 @@ from importer.functions import get_importer
 class Command(BaseCommand):
     help = 'Import the data from an oparl api into the database'
 
-    def add_arguments(self, parser, add_entrypoint=True):
+    def add_arguments(self, parser):
         from importer.oparl_helper import default_options
-        if add_entrypoint:
-            parser.add_argument('entrypoint', type=str)
+        parser.add_argument('--entrypoint', type=str)
         parser.add_argument('--cachefolder', type=str)
         parser.add_argument('--storagefolder', type=str)
         parser.add_argument('--threadcount', type=int)

--- a/mainapp/management/commands/importoparlbulk.py
+++ b/mainapp/management/commands/importoparlbulk.py
@@ -9,8 +9,8 @@ from .importoparl import Command as OParlImport
 class Command(OParlImport):
     help = 'Import the data from an oparl api into '
 
-    def add_arguments(self, parser, add_entrypoint=False):
-        super().add_arguments(parser, add_entrypoint)
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
         parser.add_argument('urlfile', type=str, default="urls-to-import.txt")
 
     def handle(self, *args, **options):

--- a/meine_stadt_transparent/settings/__init__.py
+++ b/meine_stadt_transparent/settings/__init__.py
@@ -275,6 +275,9 @@ LOGGING.update(env.json("LOGGING", {}))
 
 OPARL_ENDPOINTS_LIST = "https://dev.oparl.org/api/endpoints"
 
+OPARL_ENDPOINT = env.str("OPARL_ENDPOINT", default=None)
+OPARL_WORKAROUNDS = env.str("OPARL_WORKAROUNDS", default=None)
+
 TEMPLATE_META = {
     "logo_name": env.str('TEMPLATE_LOGO_NAME', 'MST'),
     "product_name": PRODUCT_NAME,

--- a/readme.md
+++ b/readme.md
@@ -229,22 +229,29 @@ Now the site should be working. If the "Latest Documents"-Section on the home pa
 
 To bootstrap a city, two pieces of information are required: the URL of the OParl-Endpoint, and (for now) the German "Gemeindeschlüssel".
 
-The following example uses Jülich (Gemeindeschlüssel 05358024) as an example. The OParl-Importer uses the `--use-sternberg-workarounds` to mitigate issues with the current server-side implementations.
+The following example uses Jülich (Gemeindeschlüssel 05358024) as an example. The OParl-Importer uses the Sternberg-Workarounds to mitigate issues with the current server-side implementations.
 
+OParl-related entries in the ``.env``-file:
+```txt
+OPARL_ENDPOINT=https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/system
+OPARL_WORKAROUNDS=Sternberg
+```
+
+Shell commands:
 ```bash
-./manage.py importbodies --use-sternberg-workarounds https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/system
+./manage.py importbodies
 ./manage.py importcityoutline 05358024 1
 ./manage.py importstreets 05358024 1
-./manage.py importoparl --use-sternberg-workarounds https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/system
+./manage.py importoparl
 ```
 
 ### Importing only a single object
 
 Instead of crawling the whole API, it is possible to update only one specific item using the ``importanything``-command. You will need to specify the entrypoint like always and the URL of the actual OParl-Object. Here are examples how to import a person, a paper and a meeting:
 ```bash
-./manage.py importanything --use-sternberg-workarounds https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/system https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/body/1/person/4933
-./manage.py importanything --use-sternberg-workarounds https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/system https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/body/1/paper/53584
-./manage.py importanything --use-sternberg-workarounds https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/system https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/body/1/meeting/7298
+./manage.py importanything https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/body/1/person/4933
+./manage.py importanything https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/body/1/paper/53584
+./manage.py importanything https://sdnetrim.kdvz-frechen.de/rim4240/webservice/oparl/v1/body/1/meeting/7298
 ```
 
 ### Cronjobs


### PR DESCRIPTION
Für #69 

Der Import funktioniert soweit. Aber:
- Bei der Automatic-Klasse kann ich es wegen #85 nicht sinnvoll testen
- Bei importoparlbulk kann ich es auch nicht testen, da ich nicht weiß, wie die ``urls-to-import.txt`` aufgebaut wird, bzw. wozu das genau verwendet wird.