### PR TITLE
add EMAIL_URL & ACCOUNT_MANAGEMENT_VISIBLE environment variables

### DIFF
--- a/docs/Customization.md
+++ b/docs/Customization.md
@@ -20,7 +20,9 @@ We highly recommend configuring at least mailjet, mapbox and opencage.
 
 ### E-Mail
 
-By default, we send e-mails using the local SMTP server. [Mailjet](https://dev.mailjet.com/) can be set up as an alternative for sending e-mails. Add `MAIL_PROVIDER=Mailjet` and set `MAILJET_API_KEY` and `MAILJET_SECRET_KEY` to your keys.
+By default, we send e-mails using djangos built in SMTP sending. Configure SMTP server and credentials by setting the [`EMAIL_URL`](https://github.com/joke2k/django-environ/blob/b32c07d7ed57cdeaef246f995a29e5fe39a076b3/README.rst#supported-types) environment key.
+
+[Mailjet](https://dev.mailjet.com/) can be set up as an alternative for sending e-mails. Add `MAIL_PROVIDER=Mailjet` and set `MAILJET_API_KEY` and `MAILJET_SECRET_KEY` to your keys.
 
 The e-mail-configuration can be tested using the following command line call, which sends a test e-mail to the given e-mail-address:
 
@@ -28,7 +30,9 @@ The e-mail-configuration can be tested using the following command line call, wh
 ./manage.py test-email test@example.org
 ```
 
-See the [djangop docs](https://docs.djangoproject.com/en/2.1/topics/email/) if you want to configure your only mail server instead.
+### User management
+
+User management requires a valid E-Mail configuration. If you want to hide links to register/sign in, set `ACCOUNT_MANAGEMENT_VISIBLE=False`.
 
 ### Map tiles
 
@@ -170,4 +174,3 @@ Even though it's possible to change those, you shouldn't need change them in pro
  * `ALLOWED_HOSTS`: [docs](https://docs.djangoproject.com/en/2.1/ref/settings/#allowed-hosts)
  * `PRODUCT_NAME`: Set to "Meine Stadt Transparent". Used e.g. as user agent.
  * `SECURE_HSTS_INCLUDE_SUBDOMAINS`: Wether to include subdomains in the hsts header. Defaults to true.
-

--- a/etc/template.env
+++ b/etc/template.env
@@ -13,3 +13,6 @@ MINIO_HOST=minio:9000
 
 # Delete this entry if you don't use the docker container
 STATIC_ROOT=/static
+
+# Needs to have default value
+EMAIL_URL=dummymail://

--- a/etc/test.env
+++ b/etc/test.env
@@ -13,3 +13,6 @@ ELASTICSEARCH_ENABLED=False
 ELASTICSEARCH_PREFIX=mst-test
 
 CALENDAR_HIDE_WEEKENDS=False
+
+# Needs to have default value
+EMAIL_URL=dummymail://

--- a/mainapp/templates/mainapp/person.html
+++ b/mainapp/templates/mainapp/person.html
@@ -6,7 +6,9 @@
 {% block content %}
     <div class="container">
         <section class="person-section-head">
-            <div class="float-right">{% include 'partials/subscribe_widget.html' %}</div>
+            {% if settings.ACCOUNT_MANAGEMENT_VISIBLE %}
+                <div class="float-right">{% include 'partials/subscribe_widget.html' %}</div>
+            {% endif %}
             <h1>{{ person }}</h1>
         </section>
         {% if papers %}

--- a/mainapp/templates/mainapp/search/search.html
+++ b/mainapp/templates/mainapp/search/search.html
@@ -34,7 +34,9 @@
                         <span class="fa fa-feed"></span>
                         <span class="sr-only">RSS-Feed</span>
                     </a>
-                    {% include 'partials/subscribe_widget.html' %}
+                    {% if settings.ACCOUNT_MANAGEMENT_VISIBLE %}
+                        {% include 'partials/subscribe_widget.html' %}
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/mainapp/templates/partials/base_navbar_mainmenu.html
+++ b/mainapp/templates/partials/base_navbar_mainmenu.html
@@ -16,39 +16,41 @@
         <a class="nav-link"
            href="{% url 'organizations' %}">{% trans "Organizations" context 'navigation' %}</a>
     </li>
-    {% if user.is_authenticated %}
-        <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarMyAccount" role="button"
-               data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                {% trans "My Account" context 'navigation' %}
-            </a>
-            <form class="dropdown-menu" method="POST" action="{% url 'account_logout' %}"
-                  aria-labelledby="navbarMyAccount">
-                {% csrf_token %}
-                {% if redirect_field_value %}
-                    <input type="hidden" name="{{ redirect_field_name }}"
-                           value="{{ redirect_field_value }}">
-                {% endif %}
-                <div class="dropdown-header">{{ user.email }}</div>
-                <a class="dropdown-item my-account-link" href="{% url 'profile-home' %}">
-                    {% trans 'Notifications' %}
+    {% if settings.ACCOUNT_MANAGEMENT_VISIBLE %}
+        {% if user.is_authenticated %}
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarMyAccount" role="button"
+                   data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    {% trans "My Account" context 'navigation' %}
                 </a>
-                <a class="dropdown-item change-password-link"
-                   href="{% url 'account_change_password' %}">
-                    {% trans "Change your password" %}
-                </a>
-                <div class="dropdown-divider"></div>
-                <div class="dropdown-item">
-                    <button type="submit" class="logout-button btn btn-transparent">
-                        {% trans 'Sign Out' %}
-                    </button>
-                </div>
-            </form>
-        </li>
-    {% else %}
-        <li class="nav-item">
-            <a class="nav-link login-link" rel="nofollow"
-               href="{% url 'account_login' %}?next={{ request.path }}">{% trans "Sign In" context 'navigation' %}</a>
-        </li>
+                <form class="dropdown-menu" method="POST" action="{% url 'account_logout' %}"
+                      aria-labelledby="navbarMyAccount">
+                    {% csrf_token %}
+                    {% if redirect_field_value %}
+                        <input type="hidden" name="{{ redirect_field_name }}"
+                               value="{{ redirect_field_value }}">
+                    {% endif %}
+                    <div class="dropdown-header">{{ user.email }}</div>
+                    <a class="dropdown-item my-account-link" href="{% url 'profile-home' %}">
+                        {% trans 'Notifications' %}
+                    </a>
+                    <a class="dropdown-item change-password-link"
+                       href="{% url 'account_change_password' %}">
+                        {% trans "Change your password" %}
+                    </a>
+                    <div class="dropdown-divider"></div>
+                    <div class="dropdown-item">
+                        <button type="submit" class="logout-button btn btn-transparent">
+                            {% trans 'Sign Out' %}
+                        </button>
+                    </div>
+                </form>
+            </li>
+        {% else %}
+            <li class="nav-item">
+                <a class="nav-link login-link" rel="nofollow"
+                   href="{% url 'account_login' %}?next={{ request.path }}">{% trans "Sign In" context 'navigation' %}</a>
+            </li>
+        {% endif %}
     {% endif %}
 </ul>

--- a/meine_stadt_transparent/settings/__init__.py
+++ b/meine_stadt_transparent/settings/__init__.py
@@ -412,6 +412,7 @@ SETTINGS_EXPORT = [
     "FILE_DISCLAIMER",
     "FILE_DISCLAIMER_URL",
     "ABSOLUTE_URI_BASE",
+    "ACCOUNT_MANAGEMENT_VISIBLE",
 ]
 
 # Mandatory but afaik unsused value

--- a/meine_stadt_transparent/settings/__init__.py
+++ b/meine_stadt_transparent/settings/__init__.py
@@ -53,12 +53,15 @@ if env.str("MAIL_PROVIDER", "local").lower() == "mailjet":
         "MAILJET_SECRET_KEY": env.str("MAILJET_SECRET_KEY"),
     }
     EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
-else:
+elif "EMAIL_URL" in env:
+    # If EMAIL_URL is not configured, django's SMTP defaults will be used
     EMAIL_CONFIG = env.email_url('EMAIL_URL')
     vars().update(EMAIL_CONFIG)
 
 EMAIL_FROM = env.str("EMAIL_FROM", "info@" + REAL_HOST)
 EMAIL_FROM_NAME = env.str("EMAIL_FROM_NAME", SITE_NAME)
+# required for django-allauth. See https://github.com/pennersr/django-allauth/blob/0.41.0/allauth/account/adapter.py#L95
+DEFAULT_FROM_EMAIL = f"{EMAIL_FROM_NAME} <{EMAIL_FROM}>"
 
 # Encrypted email are currently plaintext only (html is just rendered as plaintext in thunderbird),
 # which is why this feature is disabled by default

--- a/meine_stadt_transparent/settings/__init__.py
+++ b/meine_stadt_transparent/settings/__init__.py
@@ -53,6 +53,9 @@ if env.str("MAIL_PROVIDER", "local").lower() == "mailjet":
         "MAILJET_SECRET_KEY": env.str("MAILJET_SECRET_KEY"),
     }
     EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
+else:
+    EMAIL_CONFIG = env.email_url('EMAIL_URL')
+    vars().update(EMAIL_CONFIG)
 
 EMAIL_FROM = env.str("EMAIL_FROM", "info@" + REAL_HOST)
 EMAIL_FROM_NAME = env.str("EMAIL_FROM_NAME", SITE_NAME)
@@ -95,6 +98,7 @@ ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_ADAPTER = "mainapp.account_adapter.AccountAdapter"
 SOCIALACCOUNT_EMAIL_VERIFICATION = False
 SOCIALACCOUNT_QUERY_EMAIL = True
+ACCOUNT_MANAGEMENT_VISIBLE = env.bool("ACCOUNT_MANAGEMENT_VISIBLE", True)
 # Needed by allauth
 SITE_ID = 1
 


### PR DESCRIPTION
This pull request adds:

Handling of `EMAIL_URL` environment variable for SMTP configuration. I couldn't test this as I have some problems with gandi being blocked on scaleway but wanted to get your attention ahead of time. I'll ping you here once I've made sure this works.

`ACCOUNT_MANAGEMENT_VISIBLE` variable for enabling/disabling links to features requiring a valid email set up.