### PR TITLE
move subscribe-widget class to subscribe button form

### DIFF
--- a/mainapp/assets/css/_subscribe-widget.scss
+++ b/mainapp/assets/css/_subscribe-widget.scss
@@ -1,7 +1,5 @@
 .subscribe-widget {
-  form {
-    display: inline-block;
-  }
+  display: inline-block;
 }
 
 .btn-unsubscribe {

--- a/mainapp/assets/js/FacettedSearch.js
+++ b/mainapp/assets/js/FacettedSearch.js
@@ -107,6 +107,8 @@ export default class FacettedSearch {
 
             window.history.pushState({}, "", url);
 
+            $(".search-feed").attr("href", url + "feed/")
+
             this.$refreshSpinner.attr("hidden", "hidden");
         });
     }

--- a/mainapp/templates/mainapp/search/search.html
+++ b/mainapp/templates/mainapp/search/search.html
@@ -28,7 +28,7 @@
                          aria-label="The search is refreshing" hidden="hidden">
                     </div>
                 </div>
-                <div class="col col-auto subscribe-widget">
+                <div class="col col-auto">
                     <a class="btn btn-sm btn-light" href="{% url 'search-feed' query %}"
                        title="{% trans "Search results as RSS-Feed" %}">
                         <span class="fa fa-feed"></span>

--- a/mainapp/templates/mainapp/search/search.html
+++ b/mainapp/templates/mainapp/search/search.html
@@ -29,7 +29,7 @@
                     </div>
                 </div>
                 <div class="col col-auto">
-                    <a class="btn btn-sm btn-light" href="{% url 'search-feed' query %}"
+                    <a class="btn btn-sm btn-light search-feed" href="{% url 'search-feed' query %}"
                        title="{% trans "Search results as RSS-Feed" %}">
                         <span class="fa fa-feed"></span>
                         <span class="sr-only">RSS-Feed</span>

--- a/mainapp/templates/partials/subscribe_widget.html
+++ b/mainapp/templates/partials/subscribe_widget.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% if subscribable %}
-    <form method="POST">
+    <form method="POST" class="subscribe-widget">
         {% csrf_token %}
         {% if is_subscribed %}
             <button class="btn btn-unsubscribe btn-sm" name="unsubscribe" value="unsubscribe">


### PR DESCRIPTION
This fixes #239 by moving the `subscribe-widget` class to the subscribe button form.

The root cause of this is that in file [FacetttedSearch.js Line 98](https://github.com/meine-stadt-transparent/meine-stadt-transparent/blob/master/mainapp/assets/js/FacettedSearch.js#L98) the whole element gets replaced. This includes the RSS button.