### PR TITLE
Destructure webpack-merge in common webpack config

### DIFF
--- a/etc/webpack.config.common.js
+++ b/etc/webpack.config.common.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const webpack = require('webpack');
 const BundleTracker = require('webpack-bundle-tracker');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const merge = require('webpack-merge');
+const {merge} = require('webpack-merge');
 
 module.exports = {
     context: path.resolve(__dirname),


### PR DESCRIPTION
I tried to add an own customization and bumped into `Could not read file: ./customization/muenster/webpack.config.js` while executing `npm run build:prod`.

Turns out the actual error was 

```
TypeError: merge is not a function
    at /app/etc/webpack.config.common.js:131:30
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/app/etc/webpack.config.common.js:124:38)
    at Module._compile (/app/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.Module._load (internal/modules/cjs/loader.js:778:12)
    at Module.require (internal/modules/cjs/loader.js:961:19)
    at require (/app/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at Object.<anonymous> (/app/etc/webpack.config.prod.js:2:16)
```