### PR TITLE
changed base template in email.html

### DIFF
--- a/mainapp/templates/account/email.html
+++ b/mainapp/templates/account/email.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "base.html" %}
 
 {% load i18n %}
 {% load widget_tweaks %}


### PR DESCRIPTION
The email page appears without styling. To fix this i changed the base template from `{% extends "account/base.html" %}` to `{% extends "base.html" %}`.

`account/base.html` was probably deleted in previous commits and `email.html` was not updated. 