### PR TITLE
Add new setting to allow user override of fallback city for geocoding

### DIFF
--- a/docs/Customization.md
+++ b/docs/Customization.md
@@ -155,6 +155,7 @@ Meine Stadt Transparent is fully internationalized with German translations main
 * `CITY_AFFIXES`: Often the data we get contains additional information in city names, e.g. "Landdeshauptstadt München" instead of "München", which we need to cut away. `CITY_AFFIXES` contains a list of those prefixes in German, currently "Stadt", "Landeshauptstadt", "Gemeinde", "Kreisverwaltung", "Landkreis" and "Kreis.
 * `DISTRICT_REGEX`: Sometimes, there's a city and a district of the same name. Those are disambiguated by checking whether the name matches this regex. Defaults to "(^| )kreis|kreis( |$)"
 * `GEOEXTRACT_SEARCH_COUNTRY`: Sets the country for the geocoding service. Defaults to "Deutschland"
+* `GEOEXTRACT_SEARCH_CITY`: Sets the fallback city name for the geocoding service. Defaults to the name of the main body
 * `GEOEXTRACT_LANGUAGE`: Language passed to geopy for geocoding, defaults to the first part of `LANGUAGE_CODE`, i.e. "de"
 
 ## Various

--- a/importer/cli.py
+++ b/importer/cli.py
@@ -79,7 +79,7 @@ class Cli:
 
         if not skip_files:
             logger.info("Loading the files")
-            importer.load_files(fallback_city=userinput)
+            importer.load_files(fallback_city=settings.GEOEXTRACT_SEARCH_CITY or userinput)
 
         if dotenv:
             logger.info(

--- a/importer/functions.py
+++ b/importer/functions.py
@@ -161,7 +161,9 @@ def import_update(
         importer.update(body.oparl_id)
         importer.force_singlethread = True
         if download_files:
-            importer.load_files(body.short_name, update=True)
+            importer.load_files(body.short_name,
+                                fallback_city=settings.GEOEXTRACT_SEARCH_CITY,
+                                update=True)
 
 
 def fix_sort_date(import_date: datetime.datetime):

--- a/importer/management/commands/import_json.py
+++ b/importer/management/commands/import_json.py
@@ -102,7 +102,7 @@ class Command(BaseCommand):
 
         if not options["skip_download"]:
             Importer(BaseLoader(dict()), force_singlethread=True).load_files(
-                fallback_city=body.short_name
+                fallback_city=settings.GEOEXTRACT_SEARCH_CITY or body.short_name
             )
 
         if not options["no_notify_users"]:

--- a/mainapp/management/commands/rebuild-file-locations.py
+++ b/mainapp/management/commands/rebuild-file-locations.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
         file.save()
 
     def handle(self, *args, **options):
-        fallback_city = Body.objects.get(id=settings.SITE_DEFAULT_BODY).short_name
+        fallback_city = settings.GEOEXTRACT_SEARCH_CITY or Body.objects.get(id=settings.SITE_DEFAULT_BODY).short_name
 
         if options["all"]:
             all_files = File.objects.all()

--- a/meine_stadt_transparent/settings/__init__.py
+++ b/meine_stadt_transparent/settings/__init__.py
@@ -214,8 +214,10 @@ if GEOEXTRACT_ENGINE == "opencage":
 NOMINATIM_URL = env.str("NOMINATIM_URL", "https://nominatim.openstreetmap.org")
 
 # Settings for Geo-Extraction
-GEOEXTRACT_SEARCH_COUNTRY = env.str("GEOEXTRACT_SEARCH_COUNTRY", "Deutschland")
 GEOEXTRACT_LANGUAGE = env.str("GEOEXTRACT_LANGUAGE", LANGUAGE_CODE.split("-")[0])
+
+GEOEXTRACT_SEARCH_COUNTRY = env.str("GEOEXTRACT_SEARCH_COUNTRY", "Deutschland")
+GEOEXTRACT_SEARCH_CITY = env.str("GEOEXTRACT_SEARCH_CITY", None)
 
 SUBPROCESS_MAX_RAM = env.int("SUBPROCESS_MAX_RAM", 1024 * 1024 * 1024)  # 1 GB
 


### PR DESCRIPTION
In the case of Aachen, the name of the main body is not equal to the city name.
So we need a way of overriding this.