### PR TITLE
Fix setrlimit() call on Darwin

### DIFF
--- a/mainapp/functions/document_parsing.py
+++ b/mainapp/functions/document_parsing.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import sys
 import resource
 import string
 import subprocess
@@ -73,6 +74,11 @@ def limit_memory():
     the soft part so that the limit can be increased later (setting also
     the hard limit would prevent that).
     """
+
+    if sys.platform == "darwin":
+        logger.warn("Memory limits not set on Darwin!")
+        return
+
     resource.setrlimit(
         resource.RLIMIT_AS, (settings.SUBPROCESS_MAX_RAM, resource.RLIM_INFINITY)
     )


### PR DESCRIPTION
It seems that newer Darwin version fail at the setrlimit() call for the current process with the following exception:

    ValueError: current limit exceeds maximum limit