### PR TITLE
Add support for serving files directly from object storage via presigned URL redirects

### DIFF
--- a/mainapp/functions/minio.py
+++ b/mainapp/functions/minio.py
@@ -81,7 +81,7 @@ def minio_client(public: bool = False) -> Minio:
             access_key=settings.MINIO_ACCESS_KEY,
             secret_key=settings.MINIO_SECRET_KEY,
             secure=settings.MINIO_SECURE,
-            region=settings.MINIO_REGION
+            region=settings.MINIO_REGION,
         )
 
         if settings.MINIO_PUBLIC_HOST:
@@ -90,7 +90,7 @@ def minio_client(public: bool = False) -> Minio:
                 access_key=settings.MINIO_ACCESS_KEY,
                 secret_key=settings.MINIO_SECRET_KEY,
                 secure=settings.MINIO_PUBLIC_SECURE,
-                region=settings.MINIO_REGION
+                region=settings.MINIO_REGION,
             )
         else:
             _minio_public_singleton = None

--- a/mainapp/functions/minio.py
+++ b/mainapp/functions/minio.py
@@ -77,7 +77,8 @@ def minio_client() -> Minio:
             settings.MINIO_HOST,
             access_key=settings.MINIO_ACCESS_KEY,
             secret_key=settings.MINIO_SECRET_KEY,
-            secure=False,
+            secure=settings.MINIO_SECURE,
+            region=settings.MINIO_REGION
         )
         # Give a helpful error message
         try:

--- a/mainapp/views/views.py
+++ b/mainapp/views/views.py
@@ -267,22 +267,10 @@ def file_serve(request, id):
         headers["X-Robots-Tag"] = "noindex"
 
     if settings.MINIO_REDIRECT:
-        if settings.MINIO_PUBLIC_HOST:
-            endpoint = settings.MINIO_PUBLIC_HOST
-            secure = settings.MINIO_PUBLIC_SECURE
-        else:
-            endpoint = settings.MINIO_HOST
-            secure = settings.MINIO_SECURE
-
-        mc = minio_client()
-        old_base_url = mc._base_url
-        mc._base_url = minio.api.BaseURL(("https://" if secure else "http://") + endpoint, settings.MINIO_REGION)
-
-        url = minio_client().presigned_get_object(minio_file_bucket, str(id),
+        public = settings.MINIO_PUBLIC_HOST is not None
+        url = minio_client(public).presigned_get_object(minio_file_bucket, str(id),
             expires=timedelta(hours=2),
             response_headers=headers)
-
-        mc._base_url = old_base_url
 
         minio_url = urlparse(url)
 

--- a/mainapp/views/views.py
+++ b/mainapp/views/views.py
@@ -4,8 +4,6 @@ import logging
 from urllib.parse import quote, urlparse
 from datetime import timedelta
 
-import minio.api
-
 from csp.decorators import csp_update
 from django.conf import settings
 from django.db.models import Q, Count
@@ -246,12 +244,12 @@ def file_serve_proxy(
 
 
 def file_serve(request, id):
-    """ Ensure that the file is not deleted in the database """
+    """Ensure that the file is not deleted in the database"""
     file = get_object_or_404(File, id=id)
 
     name, ext = splitext(file.filename)
     if name.isnumeric() and file.name and len(file.name) < 50:
-        filename = f'{file.name}_{name}{ext}'
+        filename = f"{file.name}_{name}{ext}"
     else:
         filename = file.filename
 
@@ -268,9 +266,12 @@ def file_serve(request, id):
 
     if settings.MINIO_REDIRECT:
         public = settings.MINIO_PUBLIC_HOST is not None
-        url = minio_client(public).presigned_get_object(minio_file_bucket, str(id),
+        url = minio_client(public).presigned_get_object(
+            minio_file_bucket,
+            str(id),
             expires=timedelta(hours=2),
-            response_headers=headers)
+            response_headers=headers,
+        )
 
         minio_url = urlparse(url)
 

--- a/mainapp/views/views.py
+++ b/mainapp/views/views.py
@@ -250,13 +250,16 @@ def file_serve(request, id):
     file = get_object_or_404(File, id=id)
 
     name, ext = splitext(file.filename)
-    if name.isnumeric() and file.name:
+    if name.isnumeric() and file.name and len(file.name) < 50:
         filename = f'{file.name}_{name}{ext}'
     else:
         filename = file.filename
 
+    filename_safe = filename.encode("ascii", "ignore")
+
     headers = {
-        "Content-Disposition": f'attachment; filename="{filename}"',
+        # Encoding according to RFC5987
+        "Content-Disposition": f"attachment; filename=\"{quote(filename_safe)}\"; filename*=UTF-8''{quote(filename)}",
         "Content-Type": str(file.mime_type),
     }
 

--- a/meine_stadt_transparent/settings/__init__.py
+++ b/meine_stadt_transparent/settings/__init__.py
@@ -170,9 +170,15 @@ STATICFILES_DIRS = (
 )
 
 MINIO_PREFIX = env.str("MINIO_PREFIX", "meine-stadt-transparent-")
-MINIO_HOST = env.str("MINIO_HOST", "localhost:9000")
 MINIO_ACCESS_KEY = env.str("MINIO_ACCESS_KEY", "meinestadttransparent")
 MINIO_SECRET_KEY = env.str("MINIO_SECRET_KEY", "meinestadttransparent")
+MINIO_REGION = env.str("MINIO_REGION", "us-east-1")
+MINIO_HOST = env.str("MINIO_HOST", "localhost:9000")
+MINIO_SECURE = env.bool("MINIO_SECURE", False)
+
+MINIO_REDIRECT = env.bool("MINIO_REDIRECT", False)
+MINIO_PUBLIC_HOST = env.str("MINIO_PUBLIC_HOST", None)
+MINIO_PUBLIC_SECURE = env.bool("MINIO_PUBLIC_SECURE", True)
 
 SCHEDULES_ENABLED = env.bool("SCHEDULES_ENABLED", False)
 

--- a/meine_stadt_transparent/settings/security.py
+++ b/meine_stadt_transparent/settings/security.py
@@ -10,7 +10,7 @@ SECURE_HSTS_PRELOAD = True
 # There might be deployments where a subdomain is still without https
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("SECURE_HSTS_INCLUDE_SUBDOMAINS", True)
 
-CSP_DEFAULT_SRC = ("'self'")
+CSP_DEFAULT_SRC = "'self'"
 
 if env.bool("MINIO_REDIRECT"):
     if env.str("MINIO_PUBLIC_HOST"):

--- a/meine_stadt_transparent/settings/security.py
+++ b/meine_stadt_transparent/settings/security.py
@@ -10,6 +10,18 @@ SECURE_HSTS_PRELOAD = True
 # There might be deployments where a subdomain is still without https
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("SECURE_HSTS_INCLUDE_SUBDOMAINS", True)
 
+CSP_DEFAULT_SRC = ("'self'")
+
+if env.bool("MINIO_REDIRECT"):
+    if env.str("MINIO_PUBLIC_HOST"):
+        endpoint = env.str("MINIO_PUBLIC_HOST")
+        secure = env.bool("MINIO_PUBLIC_SECURE", True)
+    else:
+        endpoint = env.str("MINIO_HOST")
+        secure = env.bool("MINIO_SECURE", False)
+
+    CSP_DEFAULT_SRC += ("https://" if secure else "http://") + endpoint
+
 CSP_SCRIPT_SRC = ("'self'",) + env.tuple("CSP_EXTRA_SCRIPT", default=tuple())
 CSP_IMG_SRC = ("'self'", "data:") + env.tuple("CSP_EXTRA_IMG", default=tuple())
 

--- a/meine_stadt_transparent/settings/security.py
+++ b/meine_stadt_transparent/settings/security.py
@@ -12,7 +12,7 @@ SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("SECURE_HSTS_INCLUDE_SUBDOMAINS", True
 
 CSP_DEFAULT_SRC = "'self'"
 
-if env.bool("MINIO_REDIRECT"):
+if env.bool("MINIO_REDIRECT", False):
     if env.str("MINIO_PUBLIC_HOST"):
         endpoint = env.str("MINIO_PUBLIC_HOST")
         secure = env.bool("MINIO_PUBLIC_SECURE", True)


### PR DESCRIPTION
This reduces the load in the Django app.

Tested on a Ceph RadosGW cluster running via rook.io in Kubernetes.